### PR TITLE
Remove port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ db:
   volumes:
   - db_data:/var/lib/mysql
   restart: always
-  ports:
-  - "3306:3306"
   environment:
     MYSQL_ROOT_PASSWORD: root
     MYSQL_USER: senayanuser


### PR DESCRIPTION
Removing information about mysql port 3306 on docker-compose.yml. Those lines known for causing trouble when starting docker after building it.